### PR TITLE
NexSON metadata

### DIFF
--- a/modules/nexson.py
+++ b/modules/nexson.py
@@ -64,7 +64,6 @@ def xmlNameSpace():
     result["$"] = "http://www.nexml.org/2009"
     result["nex"] = "http://www.nexml.org/2009"
     result["xsi"] = "http://www.w3.org/2001/XMLSchema-instance"
-    result["cdao"] = "http://www.evolutionaryontology.org/cdao/1.0/cdao.owl#"
     result["ot"] = "http://purl.org/opentree-terms#"
     result["xsd"] = "http://www.w3.org/2001/XMLSchema#"
     return result
@@ -128,7 +127,6 @@ def doiMetaForStudy(studyid,db):
             return
         else:
            doi = 'http://dx.doi.org/' + doi
-        #names = metaNSForDCTerm()
         result = dict()
         result["@xsi:type"] = "nex:ResourceMeta"
         result["@property"] = "ot:studyPublication"
@@ -141,9 +139,7 @@ def studyPublicationMetaElt(studyid,db):
     'generates text citation metadata element for a study'
     cite = db.study(studyid).citation
     if (cite):
-        #names = metaNSForDCTerm()
         result = dict()
-        #result["@xmlns"] = names
         result["@xsi:type"] = "nex:LiteralMeta"
         result["@property"] = "ot:studyPublicationReference"
         result["$"] = cite
@@ -201,7 +197,8 @@ def otusEltForTree(tree,studyId,db):
        
 def getOtuForNode(node_id,db):
     return db.snode(node_id).otu    
-    
+
+#Generates an otu Element             
 def otuElt(otu_id,db):
     ottol_name_id = db.otu(otu_id).ottol_name
     metaElts = metaEltsForOtuElt(otu_id,ottol_name_id,db)
@@ -209,10 +206,22 @@ def otuElt(otu_id,db):
     result["@id"] = "otu" + str(otu_id)
     if (ottol_name_id):
         result["@label"]= db.ottol_name(ottol_name_id).name
+    else:
+        result["@label"]= db.otu(otu_id).label
+    if metaElts:
+        result["@about"] = "#otu" + str(otu_id)
+        result.update(metaElts)
     return result
     
-def metaEltsForOtuElt(otu_id, ottol_name,db):
-    return dict()    
+def metaEltsForOtuElt(otu_id, ottol_name_id,db):
+    if db.ottol_name(ottol_name_id):
+        idElt = dict()
+        idElt["@xsi:type"] = "nex:LiteralMeta"
+        idElt["@property"] = "ot:ottolid"
+        idElt["$"] = db.ottol_name(ottol_name_id).opentree_uid
+        return dict(meta = idElt)    
+    else:
+        return
     
     
 def taxonIdMetaForStudy(ottol_name_id,db):
@@ -331,5 +340,9 @@ def nodeElt(nodeid,db):
     otu_id = db.snode(nodeid).otu
     if (otu_id):
         result["@otu"] = 'otu' + str(otu_id)
+    if getNodeParent(nodeid,db):
+        pass
+    else:
+        result["@root"] = 'true'
     result["@id"] = 'node'+str(nodeid)
     return result

--- a/modules/nexson.py
+++ b/modules/nexson.py
@@ -246,13 +246,6 @@ def metaNSForDWCTerm():
     names["ter"] = "http://rw.tdwg.org/dwc/terms/"
     return names
     
-    
-def taxonSetElt():
-    body = dict()
-    result = dict()
-    result["taxonSet"] = body
-    return result
-    
 def treesElt(study,db):
     'generate trees element'
     idList = getTreeIDsForStudy(study,db)

--- a/modules/nexson.py
+++ b/modules/nexson.py
@@ -222,7 +222,7 @@ def metaEltsForOtuElt(otu_id, ottol_name_id,db):
         idElt = dict()
         idElt["@xsi:type"] = "nex:LiteralMeta"
         idElt["@property"] = "ot:ottolid"
-        idElt["$"] = db.ottol_name(ottol_name_id).opentree_uid
+        idElt["$"] = db.ottol_name(ottol_name_id).preottol_taxid   # was opentree_uid
         return dict(meta = idElt)    
     else:
         return

--- a/modules/nexson.py
+++ b/modules/nexson.py
@@ -30,9 +30,7 @@ def nexmlStudy(studyId,db):
     body.update(header)
     body.update(metaElts)
     body["@id"] = studyId
-    result = dict()
-    result["nexml"] = body
-    return result
+    return dict(nexml = body)
 
 def nexmlTree(tree,db):
     '''Exports one tree from a study (still a complete JSON NeXML with
@@ -47,9 +45,7 @@ def nexmlTree(tree,db):
     body.update(trees)
     body.update(header)
     body["id"] = studyId
-    result = dict()
-    result["nexml"] = body
-    return result
+    return dict(nexml = body)
 
 def nexmlHeader():
     'Header for nexml - includes namespaces and version tag (see nexml.org)'
@@ -68,6 +64,7 @@ def xmlNameSpace():
     result["nex"] = "http://www.nexml.org/2009"
     result["xsi"] = "http://www.w3.org/2001/XMLSchema-instance"
     result["cdao"] = "http://www.evolutionaryontology.org/cdao/1.0/cdao.owl#"
+    result["ot"] = "http://opentreeoflife.org"  #need CURIE prefix, URI is placeholder
     result["xsd"] = "http://www.w3.org/2001/XMLSchema#"
     return result
 
@@ -80,12 +77,10 @@ def metaEltsForNexml(studyid,db):
     doiMeta = doiMetaForStudy(studyid,db)
     if (doiMeta):
         metaArray.append(doiMeta)
-    citeMeta = citationMetaForStudy(studyid,db)
-    if (citeMeta):
-        metaArray.append(citeMeta)
-    result = dict()
-    result["meta"] = metaArray
-    return result
+    studyPublicationMeta = studyPublicationMetaElt(studyid,db)
+    if (studyPublicationMeta):
+        metaArray.append(studyPublicationMeta)
+    return dict(meta = metaArray)
 
 
 def pubYearMetaForStudy(studyid,db):
@@ -116,15 +111,15 @@ def doiMetaForStudy(studyid,db):
     else:
         return
 
-def citationMetaForStudy(studyid,db):
-    'generates doi metadata element for a study'
+def studyPublicationMetaElt(studyid,db):
+    'generates text citation metadata element for a study'
     cite = db.study(studyid).citation
     if (cite):
         names = metaNSForDCTerm()
         result = dict()
         result["@xmlns"] = names
         result["@xsi:type"] = "ns:LiteralMeta"
-        result["@property"] = "ter:bibliographicCitation"
+        result["@property"] = "ot:studyPublication"
         result["@href"] = cite
         return result
     else:
@@ -145,9 +140,7 @@ def otusEltForStudy(studyId,db):
     otusElement = dict()
     otusElement["otu"] = otuElements
     otusElement["@id"] = "otus" + str(studyId)
-    result = dict()
-    result["otus"] = otusElement
-    return result
+    return dict(otus = otusElement)
     
 def getOtuIDsForStudy(studyid,db):
     'returns a list of otu ids for otu records that link to this study'

--- a/modules/nexson.py
+++ b/modules/nexson.py
@@ -30,7 +30,8 @@ def nexmlStudy(studyId,db):
     body.update(trees)
     body.update(header)
     body.update(metaElts)
-    body["@id"] = studyId
+    body["@id"] = "study"
+    body["@about"] = "#study"
     return dict(nexml = body)
 
 def nexmlTree(tree,db):
@@ -45,7 +46,8 @@ def nexmlTree(tree,db):
     body.update(otus)
     body.update(trees)
     body.update(header)
-    body["id"] = studyId
+    body["id"] = "study"
+    body["@about"] = "#study"
     return dict(nexml = body)
 
 def nexmlHeader():
@@ -68,21 +70,24 @@ def xmlNameSpace():
     result["xsd"] = "http://www.w3.org/2001/XMLSchema#"
     return result
 
-def metaEltsForNexml(studyid,db):
+def metaEltsForNexml(study_id,db):
     'generates nexml meta elements that are children of the root nexml element'
     metaArray = []
-    curatorMeta = curatorMetaForStudy(studyid,db)
-    if (curatorMeta):
-        metaArray.append(curatorMeta)
-    treeBaseDepositMeta = treeBaseDepositMetaForStudy(studyid,db)
-    if (treeBaseDepositMeta):
-        metaArray.append(treeBaseDepositMeta)
-    doiMeta = doiMetaForStudy(studyid,db)
-    if (doiMeta):
-        metaArray.append(doiMeta)
-    studyPublicationMeta = studyPublicationMetaElt(studyid,db)
-    if (studyPublicationMeta):
+    studyPublicationMeta = studyPublicationMetaElt(study_id,db)
+    if studyPublicationMeta:
         metaArray.append(studyPublicationMeta)
+    doiMeta = doiMetaForStudy(study_id,db)
+    if doiMeta:
+        metaArray.append(doiMeta)
+    curatorMeta = curatorMetaForStudy(study_id,db)
+    if curatorMeta:
+        metaArray.append(curatorMeta)
+    treeBaseDepositMeta = treeBaseDepositMetaForStudy(study_id,db)
+    if treeBaseDepositMeta:
+        metaArray.append(treeBaseDepositMeta)
+    phylografterIdMeta = phylografterIdMetaForStudy(study_id,db)
+    if phylografterIdMeta:
+        metaArray.append(phylografterIdMeta)
     return dict(meta = metaArray)
 
 def curatorMetaForStudy(studyid,db):
@@ -148,6 +153,13 @@ def studyPublicationMetaElt(studyid,db):
     else:
         return
 
+def phylografterIdMetaForStudy(study_id,db):
+    'generates phylografter study id metadata element for a study'
+    result = dict()
+    result["@xsi:type"] = "nex:LiteralMeta"
+    result["@property"] = "ot:studyid"
+    result["$"] = study_id
+    return result
 
 def otusEltForStudy(studyId,db):
     'Generates an otus block'


### PR DESCRIPTION
Covers the required metadata fields (ot:studyPublicationReference, ot:studyPublication, ot:curatorName, ot:dataDeposit, ot:studyID, and ot:ottolid).  The last one is 'faked' using the preottol_taxid since the proper value and field are not available in phylografter yet.
