### PR TITLE
Add service for dumping study table to csv (issue 33)

### DIFF
--- a/controllers/study.py
+++ b/controllers/study.py
@@ -937,3 +937,7 @@ def modified_list():
     wrapper['from']=fromTime.strftime(dtimeFormat)
     wrapper['to']=toTime.strftime(dtimeFormat)
     return wrapper
+
+def export_csv():
+    studies = db().select(db.study.ALL)
+    return dict(studies=studies)

--- a/views/study/export_csv.csv
+++ b/views/study/export_csv.csv
@@ -1,0 +1,7 @@
+{{
+import cStringIO
+stream=cStringIO.StringIO()
+studies.export_to_csv_file(stream)
+response.headers['Content-Type']='application/vnd.ms-excel'
+response.write(stream.getvalue(), escape=False)
+}}


### PR DESCRIPTION
Implement service to dump contents of the study table to csv (.../phylografter/study/export_csv.csv).  
