### PR TITLE
Prevent generation of null ot:ottolid values

### DIFF
--- a/modules/nexson.py
+++ b/modules/nexson.py
@@ -230,11 +230,12 @@ def otuElt(otu_id,db):
 #will be added in the future.    
 def metaEltsForOtuElt(otu_id, ottol_name_id,db):
     'generates meta elements for an otu element'
-    if db.ottol_name(ottol_name_id):
+    oname = db.ottol_name(ottol_name_id)
+    if oname and oname.accepted_uid:
         idElt = dict()
         idElt["@xsi:type"] = "nex:LiteralMeta"
         idElt["@property"] = "ot:ottolid"
-        idElt["$"] = db.ottol_name(ottol_name_id).accepted_uid
+        idElt["$"] = oname.accepted_uid
         return dict(meta = idElt)    
     else:
         return


### PR DESCRIPTION
Suppresses generation of ottolid meta data (for an otu) if the ottol_name for the otu has no accepted uid set.  Test case for this is otu1639 ("Parmentiera cerifera") in study 14.  This pull request addresses issue37 (close appropriately).
