### PR TITLE
Default redirect (post-login) specifies controller.

### DIFF
--- a/models/db.py
+++ b/models/db.py
@@ -76,9 +76,9 @@ auth.settings.login_form = RPXAccount(
     )
 
 if request.controller=='default' and request.function=='user' and request.args(0)=='login':
-    auth.settings.login_next = session._next or URL('index')
+    auth.settings.login_next = session._next or URL('default', 'index')
 else:
-    session._next = URL('index')#request.env.path_info
+    session._next = URL('default', 'index')#request.env.path_info
 
 ## other login methods are in gluon/contrib/login_methods
 #########################################################################


### PR DESCRIPTION
This is the fix an occasional problem with login errors when bouncing to non-existing URLs like 'plugin_common/index'.
