### PR TITLE
Fix for #74 (truncated names in taxon dropdown)

### DIFF
--- a/static/css/web2py.css
+++ b/static/css/web2py.css
@@ -348,3 +348,8 @@ color: #222;
 }
 .ie9 #query_panel {padding-bottom:2px;}
 
+
+/* OTU mapping autocomplete should show full text */
+#_autocomplete_ottol_name_unique_name {
+    width: auto !important;
+}


### PR DESCRIPTION
Addresses issue #74 by forcing width: auto on the SELECT widget for taxon names. 
