### PR TITLE
switched ot:isOTU back to ot:isLeaf per 10/23 software call

### DIFF
--- a/modules/nexson.py
+++ b/modules/nexson.py
@@ -471,12 +471,12 @@ def node_elt(node_row,db):
 
 def meta_elts_for_node_elt(node_row,db):
     """
-    returns metadata elements for a node (currently ot:isOTU)
+    returns metadata elements for a node (currently ot:isLeaf)
     """
     result=[]
     node_id,parent,otu_id,length,isleaf = node_row
     if isleaf:
-        isOTU_elt = createLiteralMeta("ot:isOTU","true","xsd:boolean")
-        result.append(isOTU_elt)
+        isLeaf_elt = createLiteralMeta("ot:isLeaf","true","xsd:boolean")
+        result.append(isLeaf_elt)
         return dict(meta=result)
     return


### PR DESCRIPTION
After discussion, consensus was that ot:isLeaf is a more accurate predicate for this use, which strictly related to tree topology, not whether an OTU has been assigned to the node.
