### PR TITLE
Use purl address in nexson header

### DIFF
--- a/modules/nexson.py
+++ b/modules/nexson.py
@@ -59,7 +59,7 @@ def nexml_header():
     '''
     return {"@xmlns":xmlNameSpace(),
             "@version":'0.9',
-            "@nexmljson":"http://opentree.wikispaces.com/NexSON",
+            "@nexmljson":"http://purl.org/opentree/nexson",
             "@generator":"Phylografter nexml-json exporter"}
 
 def xmlNameSpace():


### PR DESCRIPTION
This is the phylografter fix for the issue reported on phylesystem.
changed @nexmljson definition to the purl for the nexson definition whic...h should point to the definition in some form
